### PR TITLE
chore(ci): remove checkout step

### DIFF
--- a/actions/bandit/action.yaml
+++ b/actions/bandit/action.yaml
@@ -92,11 +92,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Checkout code
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      with:
-        persist-credentials: false
-
     - name: Set up Python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:

--- a/actions/semgrep/action.yaml
+++ b/actions/semgrep/action.yaml
@@ -93,11 +93,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Checkout code
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      with:
-        persist-credentials: false
-
     - name: Set up Python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:

--- a/actions/trivy/action.yaml
+++ b/actions/trivy/action.yaml
@@ -110,11 +110,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Checkout code
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      with:
-        persist-credentials: false
-
     - name: Get changed files
       if: inputs.scan-scope == 'changed'
       id: changed-files

--- a/actions/zizmor/action.yml
+++ b/actions/zizmor/action.yml
@@ -65,11 +65,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Checkout code
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      with:
-        persist-credentials: false
-
     - name: Install uv
       uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v6.4.3
       with:


### PR DESCRIPTION
This PR removes checkout step from actions  as it is not flexible (e.g. it is not possible to use the action to check specific commit or branch, private repo support requires additional steps).
All dependent repos was updated to checkout code on their workflows side.

Was tested here - https://github.com/AlexanderBarabanov/geti-sdk/actions/runs/18343628618