### PR TITLE
ci: enable options for images scans

### DIFF
--- a/actions/trivy/action.yaml
+++ b/actions/trivy/action.yaml
@@ -200,7 +200,7 @@ runs:
         if [[ "$INPUTS_SCAN_TYPE" == "config" ]]; then
           # For config scans, use all default misconfig scanners or specified ones
           CMD="$CMD --misconfig-scanners $INPUTS_MISCONFIG_SCANNERS"
-        elif [[ "$INPUTS_SCAN_TYPE" == "fs" ]]; then
+        elif [[ "$INPUTS_SCAN_TYPE" == "fs" || "$INPUTS_SCAN_TYPE" == "image" ]]; then
           # For filesystem scans, use --scanners
           CMD="$CMD --scanners $INPUTS_SCANNERS --ignore-unfixed=$INPUTS_IGNORE_UNFIXED"
         fi


### PR DESCRIPTION
Enable scanner and ignore-unfixed for image type of scan.