### PR TITLE
fix(bandit): skip config `-c` if config file is not provided

### DIFF
--- a/actions/bandit/action.yaml
+++ b/actions/bandit/action.yaml
@@ -135,13 +135,20 @@ runs:
         SEVERITY=$(echo "$INPUTS_SEVERITY_LEVEL" | tr '[:upper:]' '[:lower:]')
         CONFIDENCE=$(echo "$INPUTS_CONFIDENCE_LEVEL" | tr '[:upper:]' '[:lower:]')
 
+        # Check if config file is provided
+        if [[ -f "$INPUTS_CONFIG_FILE" ]]; then
+          CONFIG_OPTION="-c $INPUTS_CONFIG_FILE"
+        else
+          CONFIG_OPTION=""
+        fi
+
         if [[ "$INPUTS_SCAN_SCOPE" == "changed" && -n "${INPUTS_ALL_CHANGED_FILES}" ]]; then
           echo "Running Bandit on changed files, output results into workflow log only"
           echo "Changed files: ${INPUTS_ALL_CHANGED_FILES}"
           FILES="${INPUTS_ALL_CHANGED_FILES}"
           bandit \
             -a file \
-            -c "$INPUTS_CONFIG_FILE" \
+            ${CONFIG_OPTION} \
             --severity-level ${SEVERITY} \
             --confidence-level ${CONFIDENCE} \
             -r ${FILES}
@@ -151,7 +158,7 @@ runs:
         elif [[ "$INPUTS_SCAN_SCOPE" == "all" ]] ; then
           echo "Running Bandit on all files in $INPUTS_PATHS"
           bandit \
-            -c "$INPUTS_CONFIG_FILE" \
+            ${CONFIG_OPTION} \
             --severity-level ${SEVERITY} \
             --confidence-level ${CONFIDENCE} \
             -f "$INPUTS_OUTPUT_FORMAT" \


### PR DESCRIPTION
This PR updates bandit action to skip -c flag if configuration file is not provided.