### PR TITLE
chore: group tools upgrade in one monthly PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -54,7 +54,7 @@
     {
       enabled: true,
       separateMajorMinor: false,
-      groupName: "Tools upgrade",
+      groupName: "Tools",
       matchManagers: ["custom.regex"],
       matchPackagePatterns: ["*"],
       schedule: ["* * 1 * *"], // every month


### PR DESCRIPTION
This PR adds a new group in `.github/renovate.json5` to batch used security tool upgrades (matched via `custom.regex`) into a single PR, scheduled to run once per month.

Tested: https://github.com/AlexanderBarabanov/geti-ci/pull/2