### PR TITLE
chore: Fix traffic audit in test bandit workflow

### DIFF
--- a/.github/workflows/test-bandit-action.yml
+++ b/.github/workflows/test-bandit-action.yml
@@ -68,6 +68,8 @@ jobs:
     permissions:
       contents: read
     steps:
+      - *harden-runner
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
Covering the missed job in test-bandit-action workflow