### PR TITLE
chore: enable tagging for `cleanup-runner`, `sign-image` and `check-paths`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,3 +90,33 @@ jobs:
         run: |
           echo "Deleting release: $TAG_NAME"
           gh release delete "$TAG_NAME" --yes --cleanup-tag=false --repo "$GITHUB_REPOSITORY"
+
+      - name: Delete release (keep tag only) - cleanup-runner
+        if: ${{ steps.release.outputs['actions/cleanup-runner--release_created'] }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.release.outputs['actions/cleanup-runner--tag_name'] }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          echo "Deleting release: $TAG_NAME"
+          gh release delete "$TAG_NAME" --yes --cleanup-tag=false --repo "$GITHUB_REPOSITORY"
+
+      - name: Delete release (keep tag only) - sign-image
+        if: ${{ steps.release.outputs['actions/sign-image--release_created'] }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.release.outputs['actions/sign-image--tag_name'] }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          echo "Deleting release: $TAG_NAME"
+          gh release delete "$TAG_NAME" --yes --cleanup-tag=false --repo "$GITHUB_REPOSITORY"
+
+      - name: Delete release (keep tag only) - check-paths
+        if: ${{ steps.release.outputs['actions/check-paths--release_created'] }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.release.outputs['actions/check-paths--tag_name'] }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          echo "Deleting release: $TAG_NAME"
+          gh release delete "$TAG_NAME" --yes --cleanup-tag=false --repo "$GITHUB_REPOSITORY"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -35,6 +35,18 @@
     "actions/cleanup-images": {
       "package-name": "cleanup-images",
       "initial-version": "0.1.0"
+    },
+    "actions/cleanup-runner": {
+      "package-name": "cleanup-runner",
+      "initial-version": "0.1.0"
+    },
+    "actions/sign-image": {
+      "package-name": "sign-image",
+      "initial-version": "0.1.0"
+    },
+    "actions/check-paths": {
+      "package-name": "check-paths",
+      "initial-version": "0.1.0"
     }
   },
   "release-type": "simple",


### PR DESCRIPTION
This PR enables tagging for the following actions: `cleanup-runner`, `sign-image` and `check-paths`.