### PR TITLE
chore: add `benchmark` to `allow-dirs`

### DIFF
--- a/actions/skill-validator/action.yaml
+++ b/actions/skill-validator/action.yaml
@@ -39,7 +39,7 @@ inputs:
   allow-dirs:
     description: "Comma-separated list of non-standard directory names to accept without warnings (e.g. evals,example-prompts). Passed as --allow-dirs to skill-validator."
     required: false
-    default: "evals,example-prompts"
+    default: "benchmark,evals,example-prompts"
   allow-flat-layouts:
     description: "Allow files at the skill root without warnings (suppresses 'unexpected file at root' warnings). Passed as --allow-flat-layouts to skill-validator."
     required: false


### PR DESCRIPTION
This PR adds `benchmark` to `allow-dirs` default value.