### PR TITLE
fix: Modify cleanup-images action to keep underlying RC untagged images

### DIFF
--- a/.github/workflows/test-cleanup-images-action.yml
+++ b/.github/workflows/test-cleanup-images-action.yml
@@ -63,15 +63,15 @@ jobs:
           DELETED: ${{ steps.cleanup.outputs.deleted }}
         run: |
           if [[ "$SCANNED_PACKAGES" != "2" ]]; then
-            echo "Error: expected 2 scanned packages, got '$SCANNED_PACKAGES'"
+            echo "::error::expected 2 scanned packages, got '$SCANNED_PACKAGES'"
             exit 1
           fi
           if [[ "$DELETED" != "0" ]]; then
-            echo "Error: dry-run must not delete anything, got deleted='$DELETED'"
+            echo "::error::dry-run must not delete anything, got deleted='$DELETED'"
             exit 1
           fi
           if [[ -z "$RETAINED_RELEASE" || -z "$CANDIDATES" ]]; then
-            echo "Error: retained-release/candidates outputs are empty"
+            echo "::error::retained-release/candidates outputs are empty"
             exit 1
           fi
           echo "✅ Dry-run test passed (scanned=$SCANNED_PACKAGES, deleted=$DELETED)"
@@ -106,7 +106,7 @@ jobs:
           OUTCOME: ${{ steps.cleanup-invalid.outcome }}
         run: |
           if [[ "$OUTCOME" != "failure" ]]; then
-            echo "Error: expected action to fail on invalid min-versions-to-keep, got outcome='$OUTCOME'"
+            echo "::error::expected action to fail on invalid min-versions-to-keep, got outcome='$OUTCOME'"
             exit 1
           fi
           echo "✅ Validation test passed (action failed as expected)"
@@ -176,8 +176,9 @@ jobs:
             exit 0
           fi
 
-          reg_token="$(curl -fsSL -u "x:${GH_TOKEN}" \
-            "https://ghcr.io/token?service=ghcr.io&scope=repository:${OWNER}/${PACKAGE}:pull" \
+          # Pass credentials via stdin config so they never appear in argv/ps.
+          reg_token="$(printf 'user = "x:%s"\n' "${GH_TOKEN}" \
+            | curl -fsSL --config - "https://ghcr.io/token?service=ghcr.io&scope=repository:${OWNER}/${PACKAGE}:pull" \
             | jq -r '.token // .access_token // empty' || true)"
           if [[ -z "${reg_token}" ]]; then
             echo "::notice::Could not obtain a registry pull token; skipping guard assertion."
@@ -189,8 +190,10 @@ jobs:
           for digest in "${retained[@]}"; do
             [[ -n "${digest}" ]] || continue
             # Omit curl -f so a non-200 yields an empty body jq ignores, not an error.
-            manifest="$(curl -sSL -H "Authorization: Bearer ${reg_token}" -H "Accept: ${accept}" \
-              "https://ghcr.io/v2/${OWNER}/${PACKAGE}/manifests/${digest}" || true)"
+            # Bearer token via stdin config to keep it out of argv.
+            manifest="$(printf 'header = "Authorization: Bearer %s"\n' "${reg_token}" \
+              | curl -sSL --config - -H "Accept: ${accept}" \
+                "https://ghcr.io/v2/${OWNER}/${PACKAGE}/manifests/${digest}" || true)"
             while read -r child; do
               [[ -n "${child}" ]] && child_digests+=("${child}")
             done < <(printf '%s' "${manifest}" | jq -r '.manifests[]?.digest // empty' 2>/dev/null)
@@ -202,19 +205,87 @@ jobs:
             exit 0
           fi
 
+          # Index the deletion candidates into a set for O(1) membership checks.
+          declare -A candidate_set=()
+          for candidate in "${candidates[@]:-}"; do
+            [[ -n "${candidate}" ]] && candidate_set["${candidate}"]=1
+          done
+
           fail=0
           for child in "${child_digests[@]}"; do
-            for candidate in "${candidates[@]:-}"; do
-              if [[ "${child}" == "${candidate}" ]]; then
-                echo "::error::Child manifest ${child} of a retained image is a deletion candidate!"
-                fail=1
-              fi
-            done
+            if [[ -n "${candidate_set[${child}]:-}" ]]; then
+              echo "::error::Child manifest ${child} of a retained image is a deletion candidate!"
+              fail=1
+            fi
           done
           if [[ "${fail}" -ne 0 ]]; then
             exit 1
           fi
           echo "✅ Guard test passed: no child manifest of a retained image is a deletion candidate."
+
+      - name: Verify develop child manifests match action's protected set
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OWNER: ${{ github.repository_owner }}
+          PACKAGE: geti-cpu
+          PROTECTED_TREE: ${{ steps.cleanup.outputs.protected-tree }}
+        run: |
+          set -euo pipefail
+          accept='application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json'
+
+          if ! gh api "orgs/${OWNER}/packages/container/${PACKAGE}" >/dev/null 2>&1; then
+            echo "::notice::Package ${PACKAGE} not accessible; skipping develop equality assertion."
+            exit 0
+          fi
+
+          # Resolve the digest of the image tagged 'develop'.
+          develop_digest="$(
+            gh api --paginate "orgs/${OWNER}/packages/container/${PACKAGE}/versions?per_page=100" \
+              | jq -sr 'map(if type=="array" then .[] else . end)
+                        | map({name, tags: (.metadata.container.tags // [])})
+                        | .[] | select(any(.tags[]?; . == "develop")) | .name' \
+              | head -n1
+          )"
+          if [[ -z "${develop_digest}" ]]; then
+            echo "::notice::No 'develop' tag found for ${PACKAGE}; skipping develop equality assertion."
+            exit 0
+          fi
+          echo "develop index digest: ${develop_digest}"
+
+          # Pass credentials via stdin config so they never appear in argv/ps.
+          reg_token="$(printf 'user = "x:%s"\n' "${GH_TOKEN}" \
+            | curl -fsSL --config - "https://ghcr.io/token?service=ghcr.io&scope=repository:${OWNER}/${PACKAGE}:pull" \
+            | jq -r '.token // .access_token // empty' || true)"
+          if [[ -z "${reg_token}" ]]; then
+            echo "::notice::Could not obtain a registry pull token; skipping develop equality assertion."
+            exit 0
+          fi
+
+          # List 1: develop child manifests resolved independently via the registry API.
+          # Bearer token via stdin config to keep it out of argv.
+          api_children="$(
+            printf 'header = "Authorization: Bearer %s"\n' "${reg_token}" \
+              | curl -sSL --config - -H "Accept: ${accept}" \
+                "https://ghcr.io/v2/${OWNER}/${PACKAGE}/manifests/${develop_digest}" \
+              | jq -c '[.manifests[]?.digest] | unique'
+          )"
+
+          # List 2: develop child manifests the action reported as protected.
+          action_children="$(
+            printf '%s' "${PROTECTED_TREE}" \
+              | jq -c '[.[] | select((.tags | split(",")) | index("develop")) | .children[]] | unique'
+          )"
+
+          echo "API-resolved develop children:      ${api_children}"
+          echo "Action-protected develop children:  ${action_children}"
+
+          if [[ "${api_children}" != "${action_children}" ]]; then
+            echo "::error::develop child manifests differ between the registry API and the action's protected set."
+            exit 1
+          fi
+          count="$(printf '%s' "${api_children}" | jq 'length')"
+          echo "✅ develop equality test passed: ${count} protected child manifest(s) match the registry."
 
   # Summary job - provides single point of success/failure
   cleanup-images-test-summary:
@@ -233,15 +304,15 @@ jobs:
           TEST_CHILD_GUARD_RESULT: ${{ needs.cleanup-images-child-guard-test.result }}
         run: |
           if [[ "$TEST_DRY_RUN_RESULT" != "success" ]]; then
-            echo "❌ Dry-run test failed"
+            echo "::error::Dry-run test failed"
             exit 1
           fi
           if [[ "$TEST_VALIDATION_RESULT" != "success" ]]; then
-            echo "❌ Validation test failed"
+            echo "::error::Validation test failed"
             exit 1
           fi
           if [[ "$TEST_CHILD_GUARD_RESULT" != "success" ]]; then
-            echo "❌ Child-manifest guard test failed"
+            echo "::error::Child-manifest guard test failed"
             exit 1
           fi
           echo "✅ All Cleanup Images action tests passed successfully!"

--- a/.github/workflows/test-cleanup-images-action.yml
+++ b/.github/workflows/test-cleanup-images-action.yml
@@ -134,7 +134,9 @@ jobs:
         uses: ./actions/cleanup-images
         with:
           packages: geti-cpu
-          min-versions-to-keep: 5
+          # 0 disables the keep-window so only the manifest-protection guard can
+          # keep a retained image's child manifests off the deletion list.
+          min-versions-to-keep: 0
           dry-run: true
           extra-retained-tags: develop
 

--- a/.github/workflows/test-cleanup-images-action.yml
+++ b/.github/workflows/test-cleanup-images-action.yml
@@ -188,7 +188,8 @@ jobs:
           child_digests=()
           for digest in "${retained[@]}"; do
             [[ -n "${digest}" ]] || continue
-            manifest="$(curl -fsSL -H "Authorization: Bearer ${reg_token}" -H "Accept: ${accept}" \
+            # Omit curl -f so a non-200 yields an empty body jq ignores, not an error.
+            manifest="$(curl -sSL -H "Authorization: Bearer ${reg_token}" -H "Accept: ${accept}" \
               "https://ghcr.io/v2/${OWNER}/${PACKAGE}/manifests/${digest}" || true)"
             while read -r child; do
               [[ -n "${child}" ]] && child_digests+=("${child}")

--- a/.github/workflows/test-cleanup-images-action.yml
+++ b/.github/workflows/test-cleanup-images-action.yml
@@ -111,12 +111,117 @@ jobs:
           fi
           echo "✅ Validation test passed (action failed as expected)"
 
+  # Test 3: Child manifests of retained images must never be deletion candidates.
+  # Runs a dry-run against a real package and independently resolves the child
+  # manifests of every retained (release/RC/latest/develop) image, asserting
+  # none of them appear in the action's deletion candidates.
+  cleanup-images-child-guard-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - *harden-runner
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run cleanup - dry run against real package
+        id: cleanup
+        uses: ./actions/cleanup-images
+        with:
+          packages: geti-cpu
+          min-versions-to-keep: 5
+          dry-run: true
+          extra-retained-tags: develop
+
+      - name: Verify child manifests of retained images are protected
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OWNER: ${{ github.repository_owner }}
+          PACKAGE: geti-cpu
+          EXTRA_TAG: develop
+          CANDIDATE_DIGESTS: ${{ steps.cleanup.outputs.candidate-digests }}
+        run: |
+          set -euo pipefail
+          release_regex='^[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$'
+
+          read -r -a candidates <<< "${CANDIDATE_DIGESTS:-}"
+          echo "Action reported ${#candidates[@]} deletion-candidate digest(s)."
+
+          if ! gh api "orgs/${OWNER}/packages/container/${PACKAGE}" >/dev/null 2>&1; then
+            echo "::notice::Package ${PACKAGE} not accessible for ${OWNER}; skipping guard assertion."
+            exit 0
+          fi
+
+          versions_json="$(
+            gh api --paginate "orgs/${OWNER}/packages/container/${PACKAGE}/versions?per_page=100" \
+              | jq -sc 'map(if type=="array" then .[] else . end)
+                        | map({name, tags: (.metadata.container.tags // [])})'
+          )"
+
+          # Digests of retained release/RC/latest/develop images.
+          mapfile -t retained < <(
+            echo "${versions_json}" | jq -r --arg re "${release_regex}" --arg extra "${EXTRA_TAG}" '.[]
+              | select(any(.tags[]?; test($re; "i") or . == "latest" or . == $extra))
+              | .name'
+          )
+          echo "Retained image digests: ${#retained[@]}"
+          if [[ "${#retained[@]}" -eq 0 ]]; then
+            echo "::notice::No retained images found; guard assertion vacuously passes."
+            exit 0
+          fi
+
+          reg_token="$(curl -fsSL -u "x:${GH_TOKEN}" \
+            "https://ghcr.io/token?service=ghcr.io&scope=repository:${OWNER}/${PACKAGE}:pull" \
+            | jq -r '.token // .access_token // empty' || true)"
+          if [[ -z "${reg_token}" ]]; then
+            echo "::notice::Could not obtain a registry pull token; skipping guard assertion."
+            exit 0
+          fi
+          accept='application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json'
+
+          child_digests=()
+          for digest in "${retained[@]}"; do
+            [[ -n "${digest}" ]] || continue
+            manifest="$(curl -fsSL -H "Authorization: Bearer ${reg_token}" -H "Accept: ${accept}" \
+              "https://ghcr.io/v2/${OWNER}/${PACKAGE}/manifests/${digest}" || true)"
+            while read -r child; do
+              [[ -n "${child}" ]] && child_digests+=("${child}")
+            done < <(printf '%s' "${manifest}" | jq -r '.manifests[]?.digest // empty' 2>/dev/null)
+          done
+          echo "Discovered ${#child_digests[@]} child manifest(s) under retained images."
+
+          if [[ "${#child_digests[@]}" -eq 0 ]]; then
+            echo "::notice::No child manifests discovered under retained images; guard assertion vacuously passes."
+            exit 0
+          fi
+
+          fail=0
+          for child in "${child_digests[@]}"; do
+            for candidate in "${candidates[@]:-}"; do
+              if [[ "${child}" == "${candidate}" ]]; then
+                echo "::error::Child manifest ${child} of a retained image is a deletion candidate!"
+                fail=1
+              fi
+            done
+          done
+          if [[ "${fail}" -ne 0 ]]; then
+            exit 1
+          fi
+          echo "✅ Guard test passed: no child manifest of a retained image is a deletion candidate."
+
   # Summary job - provides single point of success/failure
   cleanup-images-test-summary:
     runs-on: ubuntu-latest
     needs:
       - cleanup-images-dry-run-test
       - cleanup-images-validation-test
+      - cleanup-images-child-guard-test
     if: always()
     steps:
       - name: Check test results
@@ -124,6 +229,7 @@ jobs:
         env:
           TEST_DRY_RUN_RESULT: ${{ needs.cleanup-images-dry-run-test.result }}
           TEST_VALIDATION_RESULT: ${{ needs.cleanup-images-validation-test.result }}
+          TEST_CHILD_GUARD_RESULT: ${{ needs.cleanup-images-child-guard-test.result }}
         run: |
           if [[ "$TEST_DRY_RUN_RESULT" != "success" ]]; then
             echo "❌ Dry-run test failed"
@@ -131,6 +237,10 @@ jobs:
           fi
           if [[ "$TEST_VALIDATION_RESULT" != "success" ]]; then
             echo "❌ Validation test failed"
+            exit 1
+          fi
+          if [[ "$TEST_CHILD_GUARD_RESULT" != "success" ]]; then
+            echo "❌ Child-manifest guard test failed"
             exit 1
           fi
           echo "✅ All Cleanup Images action tests passed successfully!"

--- a/actions/cleanup-images/README.md
+++ b/actions/cleanup-images/README.md
@@ -17,7 +17,9 @@ It replaces per-repository cleanup workflows (such as `cleanup-old-app-images.ym
 - Release images (tags matching semver `X.Y.Z`, e.g. `3.0.0`) are **never** deleted.
 - Release-candidate images (tags matching `X.Y.ZrcN`, e.g. `3.0.0rc0`) are **never** deleted.
 - The `latest` tag is **never** deleted.
-- Among the remaining versions (dev/daily builds and untagged versions) the most recent `min-versions-to-keep` are kept; older ones are deleted.
+- Any tag listed in `extra-retained-tags` (e.g. `develop`) is **never** deleted.
+- Untagged child manifests referenced by a retained index (per-arch layers, buildx provenance/SBOM attestations) and cosign signatures/attestations of retained images are **never** deleted, so retained tags stay pullable.
+- Among the remaining versions (dev/daily builds and unreferenced untagged versions) the most recent `min-versions-to-keep` are kept; older ones are deleted.
 
 ## Usage
 
@@ -76,6 +78,7 @@ jobs:
 | `packages`             | String  | Space- or newline-separated list of GHCR container package names to clean up                          | —                                | Yes      |
 | `min-versions-to-keep` | String  | Number of most recent non-release image versions to keep per package                                  | `10`                             | No       |
 | `dry-run`              | String  | Preview deletions without removing image versions. Must be `true` or `false`                          | `true`                           | No       |
+| `extra-retained-tags`  | String  | Space- or newline-separated additional tags to never delete (e.g. `develop`). Their child manifests are protected too | `""`                             | No       |
 | `owner`                | String  | GHCR package owner (user or organization)                                                             | `${{ github.repository_owner }}` | No       |
 | `token`                | String  | Token with `packages:write` permission used to list and delete package versions                       | `${{ github.token }}`            | No       |
 
@@ -87,6 +90,7 @@ jobs:
 | `retained-release` | String | Number of release versions retained                |
 | `candidates`       | String | Number of versions matched for deletion            |
 | `deleted`          | String | Number of versions deleted (`0` in dry-run mode)   |
+| `candidate-digests`| String | Space-separated digests of versions matched for deletion |
 
 ## Required permissions
 

--- a/actions/cleanup-images/README.md
+++ b/actions/cleanup-images/README.md
@@ -12,6 +12,17 @@ It replaces per-repository cleanup workflows (such as `cleanup-old-app-images.ym
 - Dry-run mode (default) previews deletions without removing anything
 - Writes a summary of the cleanup to the workflow run summary
 
+## Prerequisites
+
+The action runs a Bash script and shells out to a few tools that must be available on the runner (all preinstalled on GitHub-hosted `ubuntu-*` runners; install them yourself on custom/self-hosted runners):
+
+- **`bash`** — the action step uses `shell: bash`.
+- **[`gh`](https://cli.github.com/) (GitHub CLI) 2.x+** — lists and deletes package versions via the GitHub API. It reads the token from the `GH_TOKEN` environment variable, which the action sets from the `token` input.
+- **[`jq`](https://jqlang.github.io/jq/) 1.6+** — parses API responses and computes the retention filter (uses `strptime`/`mktime`, `unique`, `@uri`).
+- **[`curl`](https://curl.se/) 7.x+** — resolves retained image manifests and OCI referrers from the GHCR registry to protect child manifests and cosign signatures.
+
+The registry uses the OCI [Referrers API](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers) to discover cosign artifacts; GHCR supports it. If a runner cannot reach `ghcr.io` or the tools are missing, manifest resolution is skipped with a warning and only tag-based protection applies.
+
 ## Retention rules
 
 - Release images (tags matching semver `X.Y.Z`, e.g. `3.0.0`) are **never** deleted.

--- a/actions/cleanup-images/action.yaml
+++ b/actions/cleanup-images/action.yaml
@@ -205,13 +205,15 @@ runs:
                 continue
               fi
               # Collect index children and OCI referrers with a type label.
+              # Omit curl -f so a non-200 (e.g. GHCR returns 404 for the OCI
+              # referrers endpoint) yields an empty body jq ignores, not an error.
               child_entries=()
-              manifest="$(curl -fsSL -H "Authorization: Bearer ${reg_token}" -H "Accept: ${accept}" \
+              manifest="$(curl -sSL -H "Authorization: Bearer ${reg_token}" -H "Accept: ${accept}" \
                 "https://ghcr.io/v2/${OWNER}/${package_url}/manifests/${digest}" || true)"
               while read -r child; do
                 [[ -n "${child}" ]] && child_entries+=("child"$'\t'"${child}")
               done < <(printf '%s' "${manifest}" | jq -r '.manifests[]?.digest // empty' 2>/dev/null)
-              referrers="$(curl -fsSL -H "Authorization: Bearer ${reg_token}" \
+              referrers="$(curl -sSL -H "Authorization: Bearer ${reg_token}" \
                 -H "Accept: application/vnd.oci.image.index.v1+json" \
                 "https://ghcr.io/v2/${OWNER}/${package_url}/referrers/${digest}" || true)"
               while read -r child; do

--- a/actions/cleanup-images/action.yaml
+++ b/actions/cleanup-images/action.yaml
@@ -9,6 +9,7 @@
 # - Release-candidate images (tags matching "X.Y.ZrcN", e.g. 3.0.0rc0) are
 #   NEVER deleted.
 # - The "latest" tag is NEVER deleted.
+# - Any tag listed in `extra-retained-tags` (e.g. "develop") is NEVER deleted.
 # - Untagged child manifests referenced by a retained index (per-arch layers,
 #   buildx provenance/SBOM attestations) and cosign signatures/attestations of
 #   retained images are NEVER deleted, so retained tags stay pullable.
@@ -34,6 +35,10 @@ inputs:
     description: "Preview deletions without removing image versions (true/false)"
     required: false
     default: "true"
+  extra-retained-tags:
+    description: "Space- or newline-separated additional tags to never delete (e.g. 'develop staging'). Their child manifests are protected too."
+    required: false
+    default: ""
   owner:
     description: "GHCR package owner (user or organization). Defaults to the current repository owner."
     required: false
@@ -56,6 +61,9 @@ outputs:
   deleted:
     description: "Number of versions deleted (0 in dry-run mode)"
     value: ${{ steps.cleanup.outputs.deleted }}
+  candidate-digests:
+    description: "Space-separated digests of versions matched for deletion across all packages"
+    value: ${{ steps.cleanup.outputs.candidate_digests }}
 
 runs:
   using: composite
@@ -68,6 +76,7 @@ runs:
         OWNER: ${{ inputs.owner }}
         PACKAGES: ${{ inputs.packages }}
         MIN_VERSIONS_TO_KEEP: ${{ inputs.min-versions-to-keep }}
+        EXTRA_RETAINED_TAGS: ${{ inputs.extra-retained-tags }}
         DRY_RUN: ${{ inputs.dry-run == 'false' && 'false' || 'true' }}
       run: |
         set -euo pipefail
@@ -85,10 +94,19 @@ runs:
           exit 1
         fi
 
+        # Parse the additional always-retain tags into a JSON array for jq.
+        read -r -a extra_retained_tags <<< "$(printf '%s' "${EXTRA_RETAINED_TAGS}" | tr '\n' ' ')"
+        if [[ "${#extra_retained_tags[@]}" -gt 0 ]]; then
+          extra_retained_json="$(printf '%s\n' "${extra_retained_tags[@]}" | jq -Rc . | jq -sc .)"
+        else
+          extra_retained_json='[]'
+        fi
+
         deleted=0
         candidates=0
         retained_release=0
         scanned_packages=0
+        candidate_digests=()
 
         owner_type="$(gh api "users/${OWNER}" --jq '.type')"
         if [[ "${owner_type}" == "Organization" ]]; then
@@ -103,6 +121,7 @@ runs:
         echo "Using ${scope_kind} package API scope: ${api_scope}"
         echo "Packages: ${packages[*]}"
         echo "Minimum non-release versions to keep per package: ${MIN_VERSIONS_TO_KEEP}"
+        echo "Extra always-retain tags: ${extra_retained_tags[*]:-<none>}"
         echo "Dry run: ${DRY_RUN}"
 
         for package in "${packages[@]}"; do
@@ -140,66 +159,100 @@ runs:
 
           # Count release versions retained (release/RC tag or "latest").
           pkg_retained="$(
-            echo "${versions_json}" | jq --arg re "${release_regex}" '[.[]
-              | select(any(.tags[]?; test($re; "i") or . == "latest"))] | length'
+            echo "${versions_json}" | jq --arg re "${release_regex}" --argjson extra "${extra_retained_json}" '[.[]
+              | select(any(.tags[]?; test($re; "i") or . == "latest" or (. as $t | ($extra | index($t)))))] | length'
           )"
           retained_release=$((retained_release + pkg_retained))
 
-          # Digests of the retained release/RC/"latest" versions. A tagged
-          # multi-arch image is an OCI index that references untagged child
-          # manifests (per-arch layers, buildx provenance/SBOM attestations).
-          # Those children - and cosign signatures - carry no release tag, so
-          # they must be protected explicitly or the retained index becomes
-          # dangling and unpullable after cleanup.
-          mapfile -t retained_digests < <(
-            echo "${versions_json}" | jq -r --arg re "${release_regex}" '.[]
-              | select(any(.tags[]?; test($re; "i") or . == "latest"))
-              | .name'
+          # Digests (and tags) of the retained release/RC/"latest" versions. A
+          # tagged multi-arch image is an OCI index that references untagged
+          # child manifests (per-arch layers, buildx provenance/SBOM
+          # attestations). Those children - and cosign signatures - carry no
+          # release tag, so they must be protected explicitly or the retained
+          # index becomes dangling and unpullable after cleanup.
+          mapfile -t retained_entries < <(
+            echo "${versions_json}" | jq -r --arg re "${release_regex}" --argjson extra "${extra_retained_json}" '.[]
+              | select(any(.tags[]?; test($re; "i") or . == "latest" or (. as $t | ($extra | index($t)))))
+              | "\(.name)\t\(.tags | join(","))"'
           )
 
           # Resolve every retained index to the digests it references, plus any
           # OCI referrers (cosign signatures/attestations stored via referrers).
+          # tree_lines records the discovered parent/child relationships so the
+          # (dry-run) output can be verified.
           protected_digests=()
           protected_sig_tags=()
-          if [[ "${#retained_digests[@]}" -gt 0 ]]; then
+          tree_lines=()
+          if [[ "${#retained_entries[@]}" -gt 0 ]]; then
             scope="$(printf 'repository:%s/%s:pull' "${OWNER}" "${package}" | jq -sRr @uri)"
             reg_token="$(curl -fsSL -u "x:${GH_TOKEN}" \
               "https://ghcr.io/token?service=ghcr.io&scope=${scope}" \
               | jq -r '.token // .access_token // empty' || true)"
             [[ -n "${reg_token}" ]] || echo "::warning::Failed to obtain GHCR registry token for ${OWNER}/${package}; referenced manifests/referrers will not be protected."
             accept='application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json'
-            for digest in "${retained_digests[@]}"; do
+            for entry in "${retained_entries[@]}"; do
+              digest="${entry%%$'\t'*}"
+              retained_tags="${entry#*$'\t'}"
               [[ -n "${digest}" ]] || continue
+              [[ -n "${retained_tags}" ]] || retained_tags="<untagged>"
               protected_digests+=("${digest}")
               # cosign default signature/attestation tags for this digest.
               hex="${digest#sha256:}"
               protected_sig_tags+=("sha256-${hex}.sig" "sha256-${hex}.att" "sha256-${hex}.sbom")
-              [[ -n "${reg_token}" ]] || continue
+              tree_lines+=("• ${retained_tags} (${digest})")
+              if [[ -z "${reg_token}" ]]; then
+                tree_lines+=("    └─ (manifest resolution skipped: no registry token)")
+                continue
+              fi
+              # Collect index children and OCI referrers with a type label.
+              child_entries=()
               manifest="$(curl -fsSL -H "Authorization: Bearer ${reg_token}" -H "Accept: ${accept}" \
                 "https://ghcr.io/v2/${OWNER}/${package_url}/manifests/${digest}" || true)"
               while read -r child; do
-                [[ -n "${child}" ]] || continue
-                protected_digests+=("${child}")
-                child_hex="${child#sha256:}"
-                protected_sig_tags+=("sha256-${child_hex}.sig" "sha256-${child_hex}.att" "sha256-${child_hex}.sbom")
+                [[ -n "${child}" ]] && child_entries+=("child"$'\t'"${child}")
               done < <(printf '%s' "${manifest}" | jq -r '.manifests[]?.digest // empty' 2>/dev/null)
               referrers="$(curl -fsSL -H "Authorization: Bearer ${reg_token}" \
                 -H "Accept: application/vnd.oci.image.index.v1+json" \
                 "https://ghcr.io/v2/${OWNER}/${package_url}/referrers/${digest}" || true)"
               while read -r child; do
-                [[ -n "${child}" ]] && protected_digests+=("${child}")
+                [[ -n "${child}" ]] && child_entries+=("referrer"$'\t'"${child}")
               done < <(printf '%s' "${referrers}" | jq -r '.manifests[]?.digest // empty' 2>/dev/null)
+
+              if [[ "${#child_entries[@]}" -eq 0 ]]; then
+                tree_lines+=("    └─ (no child manifests discovered)")
+                continue
+              fi
+              idx=0
+              for child_entry in "${child_entries[@]}"; do
+                idx=$((idx + 1))
+                child_kind="${child_entry%%$'\t'*}"
+                child_digest="${child_entry#*$'\t'}"
+                if [[ "${idx}" -eq "${#child_entries[@]}" ]]; then connector="└─"; else connector="├─"; fi
+                tree_lines+=("    ${connector} ${child_kind} ${child_digest}")
+                protected_digests+=("${child_digest}")
+                # Index children may themselves carry cosign artifacts.
+                if [[ "${child_kind}" == "child" ]]; then
+                  child_hex="${child_digest#sha256:}"
+                  protected_sig_tags+=("sha256-${child_hex}.sig" "sha256-${child_hex}.att" "sha256-${child_hex}.sbom")
+                fi
+              done
             done
           fi
 
+          if [[ "${#tree_lines[@]}" -gt 0 ]]; then
+            echo "Protected image tree for ${package} (${#retained_entries[@]} retained, ${#protected_digests[@]} protected digests):"
+            printf '%s\n' "${tree_lines[@]}"
+          fi
+
           # Convert the protected sets to JSON arrays for jq filtering.
+          # Deduplicate: the same digest/tag can be discovered via multiple retained tags or repeated children
           if [[ "${#protected_digests[@]}" -gt 0 ]]; then
-            protected_digests_json="$(printf '%s\n' "${protected_digests[@]}" | jq -Rc . | jq -sc .)"
+            protected_digests_json="$(printf '%s\n' "${protected_digests[@]}" | jq -Rc . | jq -sc 'unique')"
           else
             protected_digests_json='[]'
           fi
           if [[ "${#protected_sig_tags[@]}" -gt 0 ]]; then
-            protected_sig_tags_json="$(printf '%s\n' "${protected_sig_tags[@]}" | jq -Rc . | jq -sc .)"
+            protected_sig_tags_json="$(printf '%s\n' "${protected_sig_tags[@]}" | jq -Rc . | jq -sc 'unique')"
           else
             protected_sig_tags_json='[]'
           fi
@@ -208,21 +261,22 @@ runs:
           # not a manifest referenced by a retained index, and not a cosign
           # signature/attestation of a protected digest. Sorted newest first;
           # the first MIN_VERSIONS_TO_KEEP are kept.
-          # Each line is "<id>\t<comma-separated tags>".
+          # Each line is "<id>\t<digest>\t<comma-separated tags>".
           mapfile -t old_versions < <(
             echo "${versions_json}" | jq -r \
               --argjson keep "${MIN_VERSIONS_TO_KEEP}" \
               --arg re "${release_regex}" \
+              --argjson extra "${extra_retained_json}" \
               --argjson protected_digests "${protected_digests_json}" \
               --argjson protected_sig_tags "${protected_sig_tags_json}" '
               [.[]
-                | select((any(.tags[]?; test($re; "i") or . == "latest")) | not)
+                | select((any(.tags[]?; test($re; "i") or . == "latest" or (. as $t | ($extra | index($t))))) | not)
                 | select((.name as $n | $protected_digests | index($n)) | not)
                 | select((any(.tags[]?; . as $t | $protected_sig_tags | index($t))) | not)]
               | sort_by(.created_at | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime)
               | reverse
               | .[$keep:]
-              | .[] | "\(.id)\t\(.tags | join(","))"'
+              | .[] | "\(.id)\t\(.name)\t\(.tags | join(","))"'
           )
 
           echo "Release versions retained for ${package}: ${pkg_retained}"
@@ -230,13 +284,16 @@ runs:
 
           for version_entry in "${old_versions[@]}"; do
             version_id="${version_entry%%$'\t'*}"
-            version_tags="${version_entry#*$'\t'}"
+            version_rest="${version_entry#*$'\t'}"
+            version_digest="${version_rest%%$'\t'*}"
+            version_tags="${version_rest#*$'\t'}"
             [[ -n "${version_tags}" ]] || version_tags="<untagged>"
             candidates=$((candidates + 1))
+            candidate_digests+=("${version_digest}")
             if [[ "${DRY_RUN}" == "true" ]]; then
-              echo "[dry-run] Would delete ${package} version id ${version_id} (tags: ${version_tags})"
+              echo "[dry-run] Would delete ${package} version id ${version_id} digest ${version_digest} (tags: ${version_tags})"
             else
-              echo "Deleting ${package} version id ${version_id} (tags: ${version_tags})"
+              echo "Deleting ${package} version id ${version_id} digest ${version_digest} (tags: ${version_tags})"
               gh api -X DELETE "${api_scope}/packages/container/${package_url}/versions/${version_id}"
               deleted=$((deleted + 1))
             fi
@@ -250,6 +307,7 @@ runs:
           echo "retained_release=${retained_release}"
           echo "candidates=${candidates}"
           echo "deleted=${deleted}"
+          echo "candidate_digests=${candidate_digests[*]:-}"
         } >> "${GITHUB_OUTPUT}"
 
         {

--- a/actions/cleanup-images/action.yaml
+++ b/actions/cleanup-images/action.yaml
@@ -162,9 +162,11 @@ runs:
           protected_digests=()
           protected_sig_tags=()
           if [[ "${#retained_digests[@]}" -gt 0 ]]; then
+            scope="$(printf 'repository:%s/%s:pull' "${OWNER}" "${package}" | jq -sRr @uri)"
             reg_token="$(curl -fsSL -u "x:${GH_TOKEN}" \
-              "https://ghcr.io/token?service=ghcr.io&scope=repository:${OWNER}/${package}:pull" \
+              "https://ghcr.io/token?service=ghcr.io&scope=${scope}" \
               | jq -r '.token // .access_token // empty' || true)"
+            [[ -n "${reg_token}" ]] || echo "::warning::Failed to obtain GHCR registry token for ${OWNER}/${package}; referenced manifests/referrers will not be protected."
             accept='application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json'
             for digest in "${retained_digests[@]}"; do
               [[ -n "${digest}" ]] || continue

--- a/actions/cleanup-images/action.yaml
+++ b/actions/cleanup-images/action.yaml
@@ -9,8 +9,12 @@
 # - Release-candidate images (tags matching "X.Y.ZrcN", e.g. 3.0.0rc0) are
 #   NEVER deleted.
 # - The "latest" tag is NEVER deleted.
-# - Among the remaining versions (dev/daily builds and untagged versions) the
-#   most recent `min-versions-to-keep` are kept; older ones are deleted.
+# - Untagged child manifests referenced by a retained index (per-arch layers,
+#   buildx provenance/SBOM attestations) and cosign signatures/attestations of
+#   retained images are NEVER deleted, so retained tags stay pullable.
+# - Among the remaining versions (dev/daily builds and unreferenced untagged
+#   versions) the most recent `min-versions-to-keep` are kept; older ones are
+#   deleted.
 #
 # Supports a dry-run mode (default) that previews deletions without removing
 # anything.
@@ -122,7 +126,7 @@ runs:
                 map(
                   if type=="array" then .[] else . end
                 ) |
-                map({id, tags: (.metadata.container.tags // []), created_at})
+                map({id, name, tags: (.metadata.container.tags // []), created_at})
             '
           )"
 
@@ -131,22 +135,88 @@ runs:
             exit 1
           fi
 
-          # Count release versions retained (semver "X.Y.Z", RC "X.Y.ZrcN" tag or "latest").
+          # Regex matching release ("X.Y.Z") and RC ("X.Y.ZrcN") tags.
+          release_regex='^[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$'
+
+          # Count release versions retained (release/RC tag or "latest").
           pkg_retained="$(
-            echo "${versions_json}" | jq '[.[]
-              | select(any(.tags[]?;
-                  test("^[0-9]+\\.[0-9]+\\.[0-9]+(rc[0-9]+)?$"; "i") or . == "latest"))] | length'
+            echo "${versions_json}" | jq --arg re "${release_regex}" '[.[]
+              | select(any(.tags[]?; test($re; "i") or . == "latest"))] | length'
           )"
           retained_release=$((retained_release + pkg_retained))
 
-          # Non-release candidates: versions without any release/RC/"latest" tag.
-          # Sorted newest first; the first MIN_VERSIONS_TO_KEEP are kept.
+          # Digests of the retained release/RC/"latest" versions. A tagged
+          # multi-arch image is an OCI index that references untagged child
+          # manifests (per-arch layers, buildx provenance/SBOM attestations).
+          # Those children - and cosign signatures - carry no release tag, so
+          # they must be protected explicitly or the retained index becomes
+          # dangling and unpullable after cleanup.
+          mapfile -t retained_digests < <(
+            echo "${versions_json}" | jq -r --arg re "${release_regex}" '.[]
+              | select(any(.tags[]?; test($re; "i") or . == "latest"))
+              | .name'
+          )
+
+          # Resolve every retained index to the digests it references, plus any
+          # OCI referrers (cosign signatures/attestations stored via referrers).
+          protected_digests=()
+          protected_sig_tags=()
+          if [[ "${#retained_digests[@]}" -gt 0 ]]; then
+            reg_token="$(curl -fsSL -u "x:${GH_TOKEN}" \
+              "https://ghcr.io/token?service=ghcr.io&scope=repository:${OWNER}/${package}:pull" \
+              | jq -r '.token // .access_token // empty' || true)"
+            accept='application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json'
+            for digest in "${retained_digests[@]}"; do
+              [[ -n "${digest}" ]] || continue
+              protected_digests+=("${digest}")
+              # cosign default signature/attestation tags for this digest.
+              hex="${digest#sha256:}"
+              protected_sig_tags+=("sha256-${hex}.sig" "sha256-${hex}.att" "sha256-${hex}.sbom")
+              [[ -n "${reg_token}" ]] || continue
+              manifest="$(curl -fsSL -H "Authorization: Bearer ${reg_token}" -H "Accept: ${accept}" \
+                "https://ghcr.io/v2/${OWNER}/${package_url}/manifests/${digest}" || true)"
+              while read -r child; do
+                [[ -n "${child}" ]] || continue
+                protected_digests+=("${child}")
+                child_hex="${child#sha256:}"
+                protected_sig_tags+=("sha256-${child_hex}.sig" "sha256-${child_hex}.att" "sha256-${child_hex}.sbom")
+              done < <(printf '%s' "${manifest}" | jq -r '.manifests[]?.digest // empty' 2>/dev/null)
+              referrers="$(curl -fsSL -H "Authorization: Bearer ${reg_token}" \
+                -H "Accept: application/vnd.oci.image.index.v1+json" \
+                "https://ghcr.io/v2/${OWNER}/${package_url}/referrers/${digest}" || true)"
+              while read -r child; do
+                [[ -n "${child}" ]] && protected_digests+=("${child}")
+              done < <(printf '%s' "${referrers}" | jq -r '.manifests[]?.digest // empty' 2>/dev/null)
+            done
+          fi
+
+          # Convert the protected sets to JSON arrays for jq filtering.
+          if [[ "${#protected_digests[@]}" -gt 0 ]]; then
+            protected_digests_json="$(printf '%s\n' "${protected_digests[@]}" | jq -Rc . | jq -sc .)"
+          else
+            protected_digests_json='[]'
+          fi
+          if [[ "${#protected_sig_tags[@]}" -gt 0 ]]; then
+            protected_sig_tags_json="$(printf '%s\n' "${protected_sig_tags[@]}" | jq -Rc . | jq -sc .)"
+          else
+            protected_sig_tags_json='[]'
+          fi
+
+          # Non-release candidates: versions that are not release/RC/"latest",
+          # not a manifest referenced by a retained index, and not a cosign
+          # signature/attestation of a protected digest. Sorted newest first;
+          # the first MIN_VERSIONS_TO_KEEP are kept.
           # Each line is "<id>\t<comma-separated tags>".
           mapfile -t old_versions < <(
-            echo "${versions_json}" | jq -r --argjson keep "${MIN_VERSIONS_TO_KEEP}" '
+            echo "${versions_json}" | jq -r \
+              --argjson keep "${MIN_VERSIONS_TO_KEEP}" \
+              --arg re "${release_regex}" \
+              --argjson protected_digests "${protected_digests_json}" \
+              --argjson protected_sig_tags "${protected_sig_tags_json}" '
               [.[]
-                | select((any(.tags[]?;
-                    test("^[0-9]+\\.[0-9]+\\.[0-9]+(rc[0-9]+)?$"; "i") or . == "latest")) | not)]
+                | select((any(.tags[]?; test($re; "i") or . == "latest")) | not)
+                | select((.name as $n | $protected_digests | index($n)) | not)
+                | select((any(.tags[]?; . as $t | $protected_sig_tags | index($t))) | not)]
               | sort_by(.created_at | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime)
               | reverse
               | .[$keep:]

--- a/actions/cleanup-images/action.yaml
+++ b/actions/cleanup-images/action.yaml
@@ -64,6 +64,9 @@ outputs:
   candidate-digests:
     description: "Space-separated digests of versions matched for deletion across all packages"
     value: ${{ steps.cleanup.outputs.candidate_digests }}
+  protected-tree:
+    description: "Compact JSON array of retained images and their protected child manifests: [{package, tags, digest, children:[...]}]"
+    value: ${{ steps.cleanup.outputs.protected_tree }}
 
 runs:
   using: composite
@@ -107,6 +110,7 @@ runs:
         retained_release=0
         scanned_packages=0
         candidate_digests=()
+        protected_tree_entries=()
 
         owner_type="$(gh api "users/${OWNER}" --jq '.type')"
         if [[ "${owner_type}" == "Organization" ]]; then
@@ -185,8 +189,9 @@ runs:
           tree_lines=()
           if [[ "${#retained_entries[@]}" -gt 0 ]]; then
             scope="$(printf 'repository:%s/%s:pull' "${OWNER}" "${package}" | jq -sRr @uri)"
-            reg_token="$(curl -fsSL -u "x:${GH_TOKEN}" \
-              "https://ghcr.io/token?service=ghcr.io&scope=${scope}" \
+            # Pass credentials via stdin config so they never appear in argv/ps.
+            reg_token="$(printf 'user = "x:%s"\n' "${GH_TOKEN}" \
+              | curl -fsSL --config - "https://ghcr.io/token?service=ghcr.io&scope=${scope}" \
               | jq -r '.token // .access_token // empty' || true)"
             [[ -n "${reg_token}" ]] || echo "::warning::Failed to obtain GHCR registry token for ${OWNER}/${package}; referenced manifests/referrers will not be protected."
             accept='application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json'
@@ -207,18 +212,38 @@ runs:
               # Collect index children and OCI referrers with a type label.
               # Omit curl -f so a non-200 (e.g. GHCR returns 404 for the OCI
               # referrers endpoint) yields an empty body jq ignores, not an error.
+              # The bearer token is passed via stdin config to keep it out of argv.
               child_entries=()
-              manifest="$(curl -sSL -H "Authorization: Bearer ${reg_token}" -H "Accept: ${accept}" \
-                "https://ghcr.io/v2/${OWNER}/${package_url}/manifests/${digest}" || true)"
+              manifest="$(printf 'header = "Authorization: Bearer %s"\n' "${reg_token}" \
+                | curl -sSL --config - -H "Accept: ${accept}" \
+                  "https://ghcr.io/v2/${OWNER}/${package_url}/manifests/${digest}" || true)"
               while read -r child; do
                 [[ -n "${child}" ]] && child_entries+=("child"$'\t'"${child}")
               done < <(printf '%s' "${manifest}" | jq -r '.manifests[]?.digest // empty' 2>/dev/null)
-              referrers="$(curl -sSL -H "Authorization: Bearer ${reg_token}" \
-                -H "Accept: application/vnd.oci.image.index.v1+json" \
-                "https://ghcr.io/v2/${OWNER}/${package_url}/referrers/${digest}" || true)"
+              referrers="$(printf 'header = "Authorization: Bearer %s"\n' "${reg_token}" \
+                | curl -sSL --config - -H "Accept: application/vnd.oci.image.index.v1+json" \
+                  "https://ghcr.io/v2/${OWNER}/${package_url}/referrers/${digest}" || true)"
               while read -r child; do
                 [[ -n "${child}" ]] && child_entries+=("referrer"$'\t'"${child}")
               done < <(printf '%s' "${referrers}" | jq -r '.manifests[]?.digest // empty' 2>/dev/null)
+
+              # Record this retained image's index (kind "child") manifests for
+              # the protected-tree output, keyed by package/tags/digest.
+              entry_child_digests=()
+              for ce in "${child_entries[@]}"; do
+                [[ "${ce%%$'\t'*}" == "child" ]] && entry_child_digests+=("${ce#*$'\t'}")
+              done
+              if [[ "${#entry_child_digests[@]}" -gt 0 ]]; then
+                children_json="$(printf '%s\n' "${entry_child_digests[@]}" | jq -Rc . | jq -sc 'unique')"
+              else
+                children_json='[]'
+              fi
+              protected_tree_entries+=("$(jq -nc \
+                --arg package "${package}" \
+                --arg tags "${retained_tags}" \
+                --arg digest "${digest}" \
+                --argjson children "${children_json}" \
+                '{package: $package, tags: $tags, digest: $digest, children: $children}')")
 
               if [[ "${#child_entries[@]}" -eq 0 ]]; then
                 tree_lines+=("    └─ (no child manifests discovered)")
@@ -310,6 +335,11 @@ runs:
           echo "candidates=${candidates}"
           echo "deleted=${deleted}"
           echo "candidate_digests=${candidate_digests[*]:-}"
+          if [[ "${#protected_tree_entries[@]}" -gt 0 ]]; then
+            echo "protected_tree=$(printf '%s\n' "${protected_tree_entries[@]}" | jq -sc .)"
+          else
+            echo "protected_tree=[]"
+          fi
         } >> "${GITHUB_OUTPUT}"
 
         {


### PR DESCRIPTION
This is related to [issue](https://github.com/open-edge-platform/geti/issues/7256)